### PR TITLE
Add PDF page extraction result

### DIFF
--- a/packages/markitdown/README.md
+++ b/packages/markitdown/README.md
@@ -39,6 +39,13 @@ result = md.convert("test.xlsx")
 print(result.text_content)
 ```
 
+```python
+# Retrieve page level content from PDFs
+result = md.convert("test.pdf", return_pages=True)
+for page in result.pages:
+    print(page.page_number, len(page.markdown))
+```
+
 ### More Information
 
 For more information, and full documentation, see the project [README.md](https://github.com/microsoft/markitdown) on GitHub.

--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -8,7 +8,12 @@ from ._markitdown import (
     PRIORITY_SPECIFIC_FILE_FORMAT,
     PRIORITY_GENERIC_FILE_FORMAT,
 )
-from ._base_converter import DocumentConverterResult, DocumentConverter
+from ._base_converter import (
+    DocumentConverterResult,
+    DocumentConverter,
+    DocumentPage,
+    PagedDocumentConverterResult,
+)
 from ._stream_info import StreamInfo
 from ._exceptions import (
     MarkItDownException,
@@ -23,6 +28,8 @@ __all__ = [
     "MarkItDown",
     "DocumentConverter",
     "DocumentConverterResult",
+    "DocumentPage",
+    "PagedDocumentConverterResult",
     "MarkItDownException",
     "MissingDependencyException",
     "FailedConversionAttempt",

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,4 +1,5 @@
-from typing import Any, BinaryIO, Optional
+from dataclasses import dataclass
+from typing import Any, BinaryIO, Optional, List, Sequence
 from ._stream_info import StreamInfo
 
 
@@ -37,6 +38,23 @@ class DocumentConverterResult:
     def __str__(self) -> str:
         """Return the converted Markdown text."""
         return self.markdown
+
+
+@dataclass
+class DocumentPage:
+    """Represent a single page of converted content."""
+
+    page_number: int
+    markdown: str
+
+
+class PagedDocumentConverterResult(DocumentConverterResult):
+    """A DocumentConverterResult that also stores page-level content."""
+
+    def __init__(self, pages: Sequence[DocumentPage], *, title: Optional[str] = None):
+        self.pages: List[DocumentPage] = list(pages)
+        markdown = "".join(page.markdown for page in self.pages)
+        super().__init__(markdown=markdown, title=title)
 
 
 class DocumentConverter:

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -4,7 +4,12 @@ import io
 from typing import BinaryIO, Any
 
 
-from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._base_converter import (
+    DocumentConverter,
+    DocumentConverterResult,
+    DocumentPage,
+    PagedDocumentConverterResult,
+)
 from .._stream_info import StreamInfo
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
@@ -72,6 +77,19 @@ class PdfConverter(DocumentConverter):
             )
 
         assert isinstance(file_stream, io.IOBase)  # for mypy
-        return DocumentConverterResult(
-            markdown=pdfminer.high_level.extract_text(file_stream),
-        )
+        return_pages = kwargs.get("return_pages", False)
+
+        markdown_text = pdfminer.high_level.extract_text(file_stream)
+        if not return_pages:
+            return DocumentConverterResult(markdown=markdown_text)
+
+        # Build page list with numbers
+        pages: list[DocumentPage] = []
+        file_stream.seek(0)
+        page_count = sum(1 for _ in pdfminer.high_level.extract_pages(file_stream))
+        for i in range(page_count):
+            file_stream.seek(0)
+            page_text = pdfminer.high_level.extract_text(file_stream, page_numbers=[i])
+            pages.append(DocumentPage(page_number=i + 1, markdown=page_text))
+
+        return PagedDocumentConverterResult(pages=pages)

--- a/packages/markitdown/tests/test_pdf_pages.py
+++ b/packages/markitdown/tests/test_pdf_pages.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+from markitdown import MarkItDown, PagedDocumentConverterResult
+
+from .test_module_misc import PDF_TEST_STRINGS
+
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+def test_pdf_return_pages():
+    markitdown = MarkItDown()
+    result = markitdown.convert(os.path.join(TEST_FILES_DIR, "test.pdf"), return_pages=True)
+    assert isinstance(result, PagedDocumentConverterResult)
+    assert len(result.pages) == 1
+    assert result.pages[0].page_number == 1
+    for expected in PDF_TEST_STRINGS:
+        assert expected in result.pages[0].markdown


### PR DESCRIPTION
## Summary
- expose page-level results via new `PagedDocumentConverterResult`
- extend `PdfConverter` to optionally return page list with `return_pages=True`
- document new feature in README
- export new classes
- add regression test for returning page numbers

## Testing
- `pytest packages/markitdown/tests/test_pdf_pages.py -q`