### PR TITLE
Add docx pagination for soft breaks, add pagination for xlsx where pa…

### DIFF
--- a/packages/markitdown/pyproject.toml
+++ b/packages/markitdown/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "charset-normalizer",
   "defusedxml",
   "onnxruntime<=1.20.1; sys_platform == 'win32'",
+  "python-docx>=1.2.0",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +42,7 @@ all = [
   "openpyxl",
   "xlrd",
   "lxml",
+  "python-docx",
   "pdfminer.six",
   "olefile",
   "pydub",
@@ -50,7 +52,7 @@ all = [
   "azure-identity"
 ]
 pptx = ["python-pptx"]
-docx = ["mammoth", "lxml"]
+docx = ["mammoth", "lxml", "python-docx"]
 xlsx = ["pandas", "openpyxl"]
 xls = ["pandas", "xlrd"]
 pdf = ["pdfminer.six"]

--- a/packages/markitdown/src/markitdown/__init__.py
+++ b/packages/markitdown/src/markitdown/__init__.py
@@ -8,7 +8,7 @@ from ._markitdown import (
     PRIORITY_SPECIFIC_FILE_FORMAT,
     PRIORITY_GENERIC_FILE_FORMAT,
 )
-from ._base_converter import DocumentConverterResult, DocumentConverter
+from ._base_converter import DocumentConverterResult, DocumentConverter, PageInfo
 from ._stream_info import StreamInfo
 from ._exceptions import (
     MarkItDownException,
@@ -23,6 +23,7 @@ __all__ = [
     "MarkItDown",
     "DocumentConverter",
     "DocumentConverterResult",
+    "PageInfo",
     "MarkItDownException",
     "MissingDependencyException",
     "FailedConversionAttempt",

--- a/packages/markitdown/src/markitdown/__main__.py
+++ b/packages/markitdown/src/markitdown/__main__.py
@@ -217,8 +217,8 @@ def main():
         )
     else:
         result = markitdown.convert(
-            args.filename, 
-            stream_info=stream_info, 
+            args.filename,
+            stream_info=stream_info,
             keep_data_uris=args.keep_data_uris,
             extract_pages=args.extract_pages,
         )
@@ -229,20 +229,17 @@ def main():
 def _handle_output(args, result: DocumentConverterResult):
     """Handle output to stdout or file"""
     output_content = ""
-    
+
     if args.extract_pages and result.pages and args.pages_json:
         # Output as JSON with page information
         pages_data = [
-            {
-                "page_number": page.page_number,
-                "content": page.content
-            }
+            {"page_number": page.page_number, "content": page.content}
             for page in result.pages
         ]
         output_data = {
             "markdown": result.markdown,
             "title": result.title,
-            "pages": pages_data
+            "pages": pages_data,
         }
         output_content = json.dumps(output_data, ensure_ascii=False, indent=2)
     elif args.extract_pages and result.pages:
@@ -251,7 +248,7 @@ def _handle_output(args, result: DocumentConverterResult):
         output_content += "\n\n" + "=" * 50 + "\n"
         output_content += f"EXTRACTED {len(result.pages)} PAGES:\n"
         output_content += "=" * 50 + "\n\n"
-        
+
         for page in result.pages:
             output_content += f"--- PAGE {page.page_number} ---\n"
             output_content += page.content
@@ -259,7 +256,7 @@ def _handle_output(args, result: DocumentConverterResult):
     else:
         # Standard output
         output_content = result.markdown
-    
+
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(output_content)

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -4,11 +4,11 @@ from ._stream_info import StreamInfo
 
 class PageInfo:
     """Information about a specific page in a document."""
-    
+
     def __init__(self, page_number: int, content: str):
         """
         Initialize page information.
-        
+
         Parameters:
         - page_number: The page number (1-indexed)
         - content: The markdown content of the page

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,5 +1,20 @@
-from typing import Any, BinaryIO, Optional
+from typing import Any, BinaryIO, Optional, List
 from ._stream_info import StreamInfo
+
+
+class PageInfo:
+    """Information about a specific page in a document."""
+    
+    def __init__(self, page_number: int, content: str):
+        """
+        Initialize page information.
+        
+        Parameters:
+        - page_number: The page number (1-indexed)
+        - content: The markdown content of the page
+        """
+        self.page_number = page_number
+        self.content = content
 
 
 class DocumentConverterResult:
@@ -10,19 +25,22 @@ class DocumentConverterResult:
         markdown: str,
         *,
         title: Optional[str] = None,
+        pages: Optional[List[PageInfo]] = None,
     ):
         """
         Initialize the DocumentConverterResult.
 
         The only required parameter is the converted Markdown text.
-        The title, and any other metadata that may be added in the future, are optional.
+        The title, pages, and any other metadata that may be added in the future, are optional.
 
         Parameters:
         - markdown: The converted Markdown text.
         - title: Optional title of the document.
+        - pages: Optional list of page information for documents with page structure.
         """
         self.markdown = markdown
         self.title = title
+        self.pages = pages
 
     @property
     def text_content(self) -> str:
@@ -69,7 +87,7 @@ class DocumentConverter:
         data = file_stream.read(100) # ... peek at the first 100 bytes, etc.
         file_stream.seek(cur_pos)    # Reset the position to the original position
 
-        Prameters:
+        Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
         - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
         - kwargs: Additional keyword arguments for the converter.
@@ -90,7 +108,7 @@ class DocumentConverter:
         """
         Convert a document to Markdown text.
 
-        Prameters:
+        Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
         - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
         - kwargs: Additional keyword arguments for the converter.

--- a/packages/markitdown/src/markitdown/_stream_info.py
+++ b/packages/markitdown/src/markitdown/_stream_info.py
@@ -11,9 +11,9 @@ class StreamInfo:
     mimetype: Optional[str] = None
     extension: Optional[str] = None
     charset: Optional[str] = None
-    filename: Optional[str] = (
-        None  # From local path, url, or Content-Disposition header
-    )
+    filename: Optional[
+        str
+    ] = None  # From local path, url, or Content-Disposition header
     local_path: Optional[str] = None  # If read from disk
     url: Optional[str] = None  # If read from url
 

--- a/packages/markitdown/src/markitdown/_stream_info.py
+++ b/packages/markitdown/src/markitdown/_stream_info.py
@@ -11,9 +11,9 @@ class StreamInfo:
     mimetype: Optional[str] = None
     extension: Optional[str] = None
     charset: Optional[str] = None
-    filename: Optional[
-        str
-    ] = None  # From local path, url, or Content-Disposition header
+    filename: Optional[str] = (
+        None  # From local path, url, or Content-Disposition header
+    )
     local_path: Optional[str] = None  # If read from disk
     url: Optional[str] = None  # If read from url
 

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -13,6 +13,7 @@ from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 _dependency_exc_info = None
 try:
     import mammoth
+    import docx
 except ImportError:
     # Preserve the error and stack trace for later
     _dependency_exc_info = sys.exc_info()
@@ -78,18 +79,79 @@ class DocxConverter(HtmlConverter):
         style_map = kwargs.get("style_map", None)
         pre_process_stream = pre_process_docx(file_stream)
 
-        # Convert to HTML
-        html_result = mammoth.convert_to_html(pre_process_stream, style_map=style_map)
+        if extract_pages:
+            # Note: DOCX files don't have fixed pages like PDFs.
+            # Page breaks depend on rendering settings (margins, font size, etc.)
+            no_text_delimeter = "<No text>"
+            number_of_chracters_delimeter = 20
 
-        # Convert HTML to markdown
-        result = self._html_converter.convert_string(html_result.value, **kwargs)
+            def find_paragraph_soft_page_breaks(doc_stream: BinaryIO) -> list[str]:
+                """
+                Extracts and returns the text fragments following soft page breaks in a DOCX document.
+                """
+                doc = docx.Document(doc_stream)
+                soft_page_breaks = []
 
-        # Note: DOCX files don't have fixed pages like PDFs.
-        # Page breaks depend on rendering settings (margins, font size, etc.)
-        # For now, we'll return None for pages even if extract_pages is True
-        # This maintains API compatibility while acknowledging the limitation
-        pages = None
+                for x in [p.rendered_page_breaks for p in doc.paragraphs]:
+                    if x is not []:
+                        for y in x:
+                            if isinstance(y, docx.text.pagebreak.RenderedPageBreak):
+                                following_text = (
+                                    y.following_paragraph_fragment.text
+                                    if y.following_paragraph_fragment
+                                    else no_text_delimeter
+                                )
+                                soft_page_breaks.append(following_text[:number_of_chracters_delimeter])
+                return soft_page_breaks
 
-        return DocumentConverterResult(
-            markdown=result.markdown, title=result.title, pages=pages
-        )
+            def split_markdown_by_following_text(
+                markdown_text: str, following_texts: list[str]
+            ) -> list[str]:
+                """
+                Splits the given markdown text into segments based on specified following text delimiters.
+                """
+                pages = []
+                current_position = 0
+                page_number = 1
+
+                for following_text in following_texts:
+                    end_index = markdown_text.find(following_text, current_position)
+                    if end_index == -1:
+                        continue
+
+                    content = markdown_text[current_position:end_index]
+                    page_info = PageInfo(page_number=page_number, content=content)
+                    pages.append(page_info)
+                    current_position = end_index
+                    page_number += 1
+
+                if current_position < len(markdown_text):
+                    remaining_content = markdown_text[current_position:]
+                    remaining_page = PageInfo(page_number=page_number, content=remaining_content)
+                    pages.append(remaining_page)
+
+                return pages
+
+            html_result = mammoth.convert_to_html(pre_process_stream, style_map=style_map)
+            result = self._html_converter.convert_string(html_result.value, **kwargs)
+
+            soft_page_breaks = find_paragraph_soft_page_breaks(pre_process_stream)
+
+            pages = split_markdown_by_following_text(result.markdown, soft_page_breaks)
+
+            return DocumentConverterResult(
+                markdown=result.markdown,
+                title=result.title,
+                pages=pages,
+            )
+
+        else:
+
+            # Convert to HTML
+            html_result = mammoth.convert_to_html(pre_process_stream, style_map=style_map)
+            # Convert HTML to markdown
+            result = self._html_converter.convert_string(html_result.value, **kwargs)
+            pages = None
+            return DocumentConverterResult(
+                markdown=result.markdown, title=result.title, pages=pages
+            )

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -4,7 +4,7 @@ from typing import BinaryIO, Any
 
 from ._html_converter import HtmlConverter
 from ..converter_utils.docx.pre_process import pre_process_docx
-from .._base_converter import DocumentConverterResult
+from .._base_converter import DocumentConverterResult, PageInfo
 from .._stream_info import StreamInfo
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
@@ -72,9 +72,22 @@ class DocxConverter(HtmlConverter):
                 _dependency_exc_info[2]
             )
 
+        # Check if page extraction is requested
+        extract_pages = kwargs.get("extract_pages", False)
+        
         style_map = kwargs.get("style_map", None)
         pre_process_stream = pre_process_docx(file_stream)
-        return self._html_converter.convert_string(
-            mammoth.convert_to_html(pre_process_stream, style_map=style_map).value,
-            **kwargs,
-        )
+        
+        # Convert to HTML
+        html_result = mammoth.convert_to_html(pre_process_stream, style_map=style_map)
+        
+        # Convert HTML to markdown
+        result = self._html_converter.convert_string(html_result.value, **kwargs)
+        
+        # Note: DOCX files don't have fixed pages like PDFs.
+        # Page breaks depend on rendering settings (margins, font size, etc.)
+        # For now, we'll return None for pages even if extract_pages is True
+        # This maintains API compatibility while acknowledging the limitation
+        pages = None
+        
+        return DocumentConverterResult(markdown=result.markdown, title=result.title, pages=pages)

--- a/packages/markitdown/src/markitdown/converters/_docx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_docx_converter.py
@@ -74,20 +74,22 @@ class DocxConverter(HtmlConverter):
 
         # Check if page extraction is requested
         extract_pages = kwargs.get("extract_pages", False)
-        
+
         style_map = kwargs.get("style_map", None)
         pre_process_stream = pre_process_docx(file_stream)
-        
+
         # Convert to HTML
         html_result = mammoth.convert_to_html(pre_process_stream, style_map=style_map)
-        
+
         # Convert HTML to markdown
         result = self._html_converter.convert_string(html_result.value, **kwargs)
-        
+
         # Note: DOCX files don't have fixed pages like PDFs.
         # Page breaks depend on rendering settings (margins, font size, etc.)
         # For now, we'll return None for pages even if extract_pages is True
         # This maintains API compatibility while acknowledging the limitation
         pages = None
-        
-        return DocumentConverterResult(markdown=result.markdown, title=result.title, pages=pages)
+
+        return DocumentConverterResult(
+            markdown=result.markdown, title=result.title, pages=pages
+        )

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,10 +1,8 @@
 import sys
 import io
+from typing import BinaryIO, Any, List
 
-from typing import BinaryIO, Any
-
-
-from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._base_converter import DocumentConverter, DocumentConverterResult, PageInfo
 from .._stream_info import StreamInfo
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
@@ -15,6 +13,10 @@ _dependency_exc_info = None
 try:
     import pdfminer
     import pdfminer.high_level
+    from pdfminer.pdfpage import PDFPage
+    from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
+    from pdfminer.converter import TextConverter
+    from pdfminer.layout import LAParams
 except ImportError:
     # Preserve the error and stack trace for later
     _dependency_exc_info = sys.exc_info()
@@ -72,6 +74,69 @@ class PdfConverter(DocumentConverter):
             )
 
         assert isinstance(file_stream, io.IOBase)  # for mypy
-        return DocumentConverterResult(
-            markdown=pdfminer.high_level.extract_text(file_stream),
-        )
+        
+        # Check if page-level extraction is requested
+        extract_pages = kwargs.get('extract_pages', False)
+        
+        if extract_pages:
+            # Extract text page by page
+            pages = self._extract_pages(file_stream)
+            # Combine all pages for the main markdown content
+            markdown = '\n\n'.join([page.content for page in pages])
+            return DocumentConverterResult(
+                markdown=markdown,
+                pages=pages,
+            )
+        else:
+            # Default behavior - extract all text at once
+            return DocumentConverterResult(
+                markdown=pdfminer.high_level.extract_text(file_stream),
+            )
+    
+    def _extract_pages(self, file_stream: BinaryIO) -> List[PageInfo]:
+        """Extract text from each page separately."""
+        pages = []
+        
+        try:
+            # Reset stream position
+            file_stream.seek(0)
+            
+            # Create resource manager
+            rsrcmgr = PDFResourceManager()
+            laparams = LAParams()
+            
+            # Get all pages
+            pdf_pages = list(PDFPage.get_pages(file_stream))
+            
+            for page_num, page in enumerate(pdf_pages, 1):
+                output_string = None
+                device = None
+                try:
+                    # Create a new StringIO for each page
+                    output_string = io.StringIO()
+                    device = TextConverter(rsrcmgr, output_string, laparams=laparams)
+                    interpreter = PDFPageInterpreter(rsrcmgr, device)
+                    
+                    # Process the page
+                    interpreter.process_page(page)
+                    
+                    # Get the text content
+                    text = output_string.getvalue()
+                    
+                    # Add page info
+                    pages.append(PageInfo(page_number=page_num, content=text.strip()))
+                    
+                finally:
+                    # Clean up resources
+                    if device:
+                        device.close()
+                    if output_string:
+                        output_string.close()
+        
+        except Exception:
+            # If page-by-page extraction fails, fall back to full document extraction
+            file_stream.seek(0)
+            full_text = pdfminer.high_level.extract_text(file_stream)
+            pages = [PageInfo(page_number=1, content=full_text.strip())]
+        
+        return pages

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -80,7 +80,7 @@ class PptxConverter(DocumentConverter):
 
         # Check if page extraction is requested
         extract_pages = kwargs.get("extract_pages", False)
-        
+
         # Perform the conversion
         presentation = pptx.Presentation(file_stream)
         md_content = ""
@@ -157,7 +157,9 @@ class PptxConverter(DocumentConverter):
 
                 # Tables
                 if self._is_table(shape):
-                    slide_content += self._convert_table_to_markdown(shape.table, **kwargs)
+                    slide_content += self._convert_table_to_markdown(
+                        shape.table, **kwargs
+                    )
 
                 # Charts
                 if shape.has_chart:
@@ -188,13 +190,15 @@ class PptxConverter(DocumentConverter):
                 if notes_frame is not None:
                     slide_content += notes_frame.text
                 slide_content = slide_content.strip()
-            
+
             # Add to overall content
             md_content += slide_content
-            
+
             # If extracting pages, add to pages list
             if extract_pages:
-                pages.append(PageInfo(page_number=slide_num, content=slide_content.strip()))
+                pages.append(
+                    PageInfo(page_number=slide_num, content=slide_content.strip())
+                )
 
         return DocumentConverterResult(markdown=md_content.strip(), pages=pages)
 

--- a/packages/markitdown/src/markitdown/converters/_pptx_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pptx_converter.py
@@ -10,7 +10,7 @@ from operator import attrgetter
 
 from ._html_converter import HtmlConverter
 from ._llm_caption import llm_caption
-from .._base_converter import DocumentConverter, DocumentConverterResult
+from .._base_converter import DocumentConverter, DocumentConverterResult, PageInfo
 from .._stream_info import StreamInfo
 from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
@@ -78,19 +78,23 @@ class PptxConverter(DocumentConverter):
                 _dependency_exc_info[2]
             )
 
+        # Check if page extraction is requested
+        extract_pages = kwargs.get("extract_pages", False)
+        
         # Perform the conversion
         presentation = pptx.Presentation(file_stream)
         md_content = ""
+        pages = [] if extract_pages else None
         slide_num = 0
         for slide in presentation.slides:
             slide_num += 1
 
-            md_content += f"\n\n<!-- Slide number: {slide_num} -->\n"
+            slide_content = f"\n\n<!-- Slide number: {slide_num} -->\n"
 
             title = slide.shapes.title
 
             def get_shape_content(shape, **kwargs):
-                nonlocal md_content
+                nonlocal slide_content
                 # Pictures
                 if self._is_picture(shape):
                     # https://github.com/scanny/python-pptx/pull/512#issuecomment-1713100069
@@ -145,26 +149,26 @@ class PptxConverter(DocumentConverter):
                         blob = shape.image.blob
                         content_type = shape.image.content_type or "image/png"
                         b64_string = base64.b64encode(blob).decode("utf-8")
-                        md_content += f"\n![{alt_text}](data:{content_type};base64,{b64_string})\n"
+                        slide_content += f"\n![{alt_text}](data:{content_type};base64,{b64_string})\n"
                     else:
                         # A placeholder name
                         filename = re.sub(r"\W", "", shape.name) + ".jpg"
-                        md_content += "\n![" + alt_text + "](" + filename + ")\n"
+                        slide_content += "\n![" + alt_text + "](" + filename + ")\n"
 
                 # Tables
                 if self._is_table(shape):
-                    md_content += self._convert_table_to_markdown(shape.table, **kwargs)
+                    slide_content += self._convert_table_to_markdown(shape.table, **kwargs)
 
                 # Charts
                 if shape.has_chart:
-                    md_content += self._convert_chart_to_markdown(shape.chart)
+                    slide_content += self._convert_chart_to_markdown(shape.chart)
 
                 # Text areas
                 elif shape.has_text_frame:
                     if shape == title:
-                        md_content += "# " + shape.text.lstrip() + "\n"
+                        slide_content += "# " + shape.text.lstrip() + "\n"
                     else:
-                        md_content += shape.text + "\n"
+                        slide_content += shape.text + "\n"
 
                 # Group Shapes
                 if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.GROUP:
@@ -176,16 +180,23 @@ class PptxConverter(DocumentConverter):
             for shape in sorted_shapes:
                 get_shape_content(shape, **kwargs)
 
-            md_content = md_content.strip()
+            slide_content = slide_content.strip()
 
             if slide.has_notes_slide:
-                md_content += "\n\n### Notes:\n"
+                slide_content += "\n\n### Notes:\n"
                 notes_frame = slide.notes_slide.notes_text_frame
                 if notes_frame is not None:
-                    md_content += notes_frame.text
-                md_content = md_content.strip()
+                    slide_content += notes_frame.text
+                slide_content = slide_content.strip()
+            
+            # Add to overall content
+            md_content += slide_content
+            
+            # If extracting pages, add to pages list
+            if extract_pages:
+                pages.append(PageInfo(page_number=slide_num, content=slide_content.strip()))
 
-        return DocumentConverterResult(markdown=md_content.strip())
+        return DocumentConverterResult(markdown=md_content.strip(), pages=pages)
 
     def _is_picture(self, shape):
         if shape.shape_type == pptx.enum.shapes.MSO_SHAPE_TYPE.PICTURE:

--- a/packages/markitdown/tests/test_docx_page_extraction.py
+++ b/packages/markitdown/tests/test_docx_page_extraction.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3 -m pytest
+"""
+Unit tests for DOCX page extraction functionality.
+"""
+
+import os
+import tempfile
+import pytest
+from typing import Optional
+
+from markitdown import MarkItDown, PageInfo, DocumentConverterResult
+
+
+class TestDocxPageExtraction:
+    """Test cases for DOCX page extraction functionality."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.markitdown = MarkItDown()
+        self.test_docx_path = os.path.join(
+            os.path.dirname(__file__), 
+            'test_files', 
+            'test.docx'
+        )
+    
+    def test_traditional_docx_conversion(self):
+        """Test that traditional DOCX conversion works unchanged."""
+        if not os.path.exists(self.test_docx_path):
+            pytest.skip("Test DOCX file not found")
+        
+        result = self.markitdown.convert(self.test_docx_path)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None  # Should be None by default
+        
+        # Verify backward compatibility
+        assert hasattr(result, 'text_content')
+        assert result.text_content == result.markdown
+        assert str(result) == result.markdown
+    
+    def test_docx_page_extraction_enabled(self):
+        """Test DOCX conversion with page extraction enabled.
+        
+        Note: DOCX files don't have fixed pages like PDFs. 
+        Page breaks depend on rendering settings. Currently,
+        this returns None for pages even with extract_pages=True.
+        """
+        if not os.path.exists(self.test_docx_path):
+            pytest.skip("Test DOCX file not found")
+        
+        result = self.markitdown.convert(self.test_docx_path, extract_pages=True)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        
+        # Currently, DOCX doesn't support page extraction due to dynamic pagination
+        assert result.pages is None
+    
+    def test_docx_page_extraction_disabled(self):
+        """Test DOCX conversion with page extraction explicitly disabled."""
+        if not os.path.exists(self.test_docx_path):
+            pytest.skip("Test DOCX file not found")
+        
+        result = self.markitdown.convert(self.test_docx_path, extract_pages=False)
+        
+        # Should behave the same as default
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None
+    
+    def test_backward_compatibility(self):
+        """Test that all existing functionality remains intact."""
+        if not os.path.exists(self.test_docx_path):
+            pytest.skip("Test DOCX file not found")
+        
+        # Test different ways of calling convert
+        result1 = self.markitdown.convert(self.test_docx_path)
+        result2 = self.markitdown.convert(self.test_docx_path, extract_pages=False)
+        result3 = self.markitdown.convert(self.test_docx_path, extract_pages=True)
+        
+        # Results should be equivalent for markdown content
+        assert result1.markdown == result2.markdown
+        assert result1.markdown == result3.markdown
+        assert result1.title == result2.title
+        assert result1.title == result3.title
+        
+        # All should have None for pages (DOCX limitation)
+        assert result1.pages is None
+        assert result2.pages is None
+        assert result3.pages is None
+        
+        # All should work with string conversion
+        assert str(result1) == str(result2)
+        assert str(result1) == str(result3)
+        
+        # All should work with text_content property
+        assert result1.text_content == result2.text_content
+        assert result1.text_content == result3.text_content
+    
+    def test_extract_pages_parameter_types(self):
+        """Test different types for extract_pages parameter."""
+        if not os.path.exists(self.test_docx_path):
+            pytest.skip("Test DOCX file not found")
+        
+        # Test with different truthy/falsy values
+        result_false = self.markitdown.convert(self.test_docx_path, extract_pages=False)
+        result_true = self.markitdown.convert(self.test_docx_path, extract_pages=True)
+        result_none = self.markitdown.convert(self.test_docx_path, extract_pages=None)
+        result_zero = self.markitdown.convert(self.test_docx_path, extract_pages=0)
+        result_one = self.markitdown.convert(self.test_docx_path, extract_pages=1)
+        
+        # All should return None for pages (DOCX limitation)
+        assert result_false.pages is None
+        assert result_true.pages is None
+        assert result_none.pages is None
+        assert result_zero.pages is None
+        assert result_one.pages is None

--- a/packages/markitdown/tests/test_docx_page_extraction.py
+++ b/packages/markitdown/tests/test_docx_page_extraction.py
@@ -13,109 +13,107 @@ from markitdown import MarkItDown, PageInfo, DocumentConverterResult
 
 class TestDocxPageExtraction:
     """Test cases for DOCX page extraction functionality."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.markitdown = MarkItDown()
         self.test_docx_path = os.path.join(
-            os.path.dirname(__file__), 
-            'test_files', 
-            'test.docx'
+            os.path.dirname(__file__), "test_files", "test.docx"
         )
-    
+
     def test_traditional_docx_conversion(self):
         """Test that traditional DOCX conversion works unchanged."""
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
-        
+
         result = self.markitdown.convert(self.test_docx_path)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None  # Should be None by default
-        
+
         # Verify backward compatibility
-        assert hasattr(result, 'text_content')
+        assert hasattr(result, "text_content")
         assert result.text_content == result.markdown
         assert str(result) == result.markdown
-    
+
     def test_docx_page_extraction_enabled(self):
         """Test DOCX conversion with page extraction enabled.
-        
-        Note: DOCX files don't have fixed pages like PDFs. 
+
+        Note: DOCX files don't have fixed pages like PDFs.
         Page breaks depend on rendering settings. Currently,
         this returns None for pages even with extract_pages=True.
         """
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
-        
+
         result = self.markitdown.convert(self.test_docx_path, extract_pages=True)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
-        
+
         # Currently, DOCX doesn't support page extraction due to dynamic pagination
         assert result.pages is None
-    
+
     def test_docx_page_extraction_disabled(self):
         """Test DOCX conversion with page extraction explicitly disabled."""
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
-        
+
         result = self.markitdown.convert(self.test_docx_path, extract_pages=False)
-        
+
         # Should behave the same as default
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None
-    
+
     def test_backward_compatibility(self):
         """Test that all existing functionality remains intact."""
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
-        
+
         # Test different ways of calling convert
         result1 = self.markitdown.convert(self.test_docx_path)
         result2 = self.markitdown.convert(self.test_docx_path, extract_pages=False)
         result3 = self.markitdown.convert(self.test_docx_path, extract_pages=True)
-        
+
         # Results should be equivalent for markdown content
         assert result1.markdown == result2.markdown
         assert result1.markdown == result3.markdown
         assert result1.title == result2.title
         assert result1.title == result3.title
-        
+
         # All should have None for pages (DOCX limitation)
         assert result1.pages is None
         assert result2.pages is None
         assert result3.pages is None
-        
+
         # All should work with string conversion
         assert str(result1) == str(result2)
         assert str(result1) == str(result3)
-        
+
         # All should work with text_content property
         assert result1.text_content == result2.text_content
         assert result1.text_content == result3.text_content
-    
+
     def test_extract_pages_parameter_types(self):
         """Test different types for extract_pages parameter."""
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
-        
+
         # Test with different truthy/falsy values
         result_false = self.markitdown.convert(self.test_docx_path, extract_pages=False)
         result_true = self.markitdown.convert(self.test_docx_path, extract_pages=True)
         result_none = self.markitdown.convert(self.test_docx_path, extract_pages=None)
         result_zero = self.markitdown.convert(self.test_docx_path, extract_pages=0)
         result_one = self.markitdown.convert(self.test_docx_path, extract_pages=1)
-        
+
         # All should return None for pages (DOCX limitation)
         assert result_false.pages is None
         assert result_true.pages is None

--- a/packages/markitdown/tests/test_docx_page_extraction.py
+++ b/packages/markitdown/tests/test_docx_page_extraction.py
@@ -42,10 +42,6 @@ class TestDocxPageExtraction:
 
     def test_docx_page_extraction_enabled(self):
         """Test DOCX conversion with page extraction enabled.
-
-        Note: DOCX files don't have fixed pages like PDFs.
-        Page breaks depend on rendering settings. Currently,
-        this returns None for pages even with extract_pages=True.
         """
         if not os.path.exists(self.test_docx_path):
             pytest.skip("Test DOCX file not found")
@@ -57,8 +53,11 @@ class TestDocxPageExtraction:
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
 
-        # Currently, DOCX doesn't support page extraction due to dynamic pagination
-        assert result.pages is None
+        assert result.pages is not None
+        assert len(result.pages) == 2
+
+        # Markdown text should be equal to concatenation of pages
+        assert result.markdown == "".join([elem.content for elem in result.pages])
 
     def test_docx_page_extraction_disabled(self):
         """Test DOCX conversion with page extraction explicitly disabled."""
@@ -89,10 +88,12 @@ class TestDocxPageExtraction:
         assert result1.title == result2.title
         assert result1.title == result3.title
 
-        # All should have None for pages (DOCX limitation)
+        # First two should have None for pages
         assert result1.pages is None
         assert result2.pages is None
-        assert result3.pages is None
+
+        assert result3.pages is not None
+        assert len(result3.pages) == 2
 
         # All should work with string conversion
         assert str(result1) == str(result2)
@@ -109,14 +110,16 @@ class TestDocxPageExtraction:
 
         # Test with different truthy/falsy values
         result_false = self.markitdown.convert(self.test_docx_path, extract_pages=False)
-        result_true = self.markitdown.convert(self.test_docx_path, extract_pages=True)
         result_none = self.markitdown.convert(self.test_docx_path, extract_pages=None)
         result_zero = self.markitdown.convert(self.test_docx_path, extract_pages=0)
+        result_true = self.markitdown.convert(self.test_docx_path, extract_pages=True)
         result_one = self.markitdown.convert(self.test_docx_path, extract_pages=1)
 
-        # All should return None for pages (DOCX limitation)
+        # These return None for pages
         assert result_false.pages is None
-        assert result_true.pages is None
         assert result_none.pages is None
         assert result_zero.pages is None
-        assert result_one.pages is None
+
+        # These return not None for pages
+        assert result_true.pages is not None
+        assert result_one.pages is not None

--- a/packages/markitdown/tests/test_pdf_page_extraction.py
+++ b/packages/markitdown/tests/test_pdf_page_extraction.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3 -m pytest
+"""
+Unit tests for PDF page extraction functionality.
+"""
+
+import os
+import tempfile
+import pytest
+from typing import Optional
+
+from markitdown import MarkItDown, PageInfo, DocumentConverterResult
+
+
+class TestPdfPageExtraction:
+    """Test cases for PDF page extraction functionality."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.markitdown = MarkItDown()
+        self.test_pdf_path = os.path.join(
+            os.path.dirname(__file__), 
+            'test_files', 
+            'test.pdf'
+        )
+    
+    def test_traditional_pdf_conversion(self):
+        """Test that traditional PDF conversion works unchanged."""
+        if not os.path.exists(self.test_pdf_path):
+            pytest.skip("Test PDF file not found")
+        
+        result = self.markitdown.convert(self.test_pdf_path)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None  # Should be None by default
+        
+        # Verify backward compatibility
+        assert hasattr(result, 'text_content')
+        assert result.text_content == result.markdown
+        assert str(result) == result.markdown
+    
+    def test_pdf_page_extraction_enabled(self):
+        """Test PDF conversion with page extraction enabled."""
+        if not os.path.exists(self.test_pdf_path):
+            pytest.skip("Test PDF file not found")
+        
+        result = self.markitdown.convert(self.test_pdf_path, extract_pages=True)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is not None
+        assert isinstance(result.pages, list)
+        assert len(result.pages) > 0
+        
+        # Verify page structure
+        for page in result.pages:
+            assert isinstance(page, PageInfo)
+            assert isinstance(page.page_number, int)
+            assert page.page_number > 0
+            assert isinstance(page.content, str)
+            assert len(page.content) > 0
+        
+        # Verify page numbers are sequential
+        page_numbers = [page.page_number for page in result.pages]
+        assert page_numbers == list(range(1, len(result.pages) + 1))
+    
+    def test_pdf_page_extraction_disabled(self):
+        """Test PDF conversion with page extraction explicitly disabled."""
+        if not os.path.exists(self.test_pdf_path):
+            pytest.skip("Test PDF file not found")
+        
+        result = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
+        
+        # Should behave the same as default
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None
+    
+    def test_page_info_class(self):
+        """Test PageInfo class functionality."""
+        page = PageInfo(page_number=1, content="Test content")
+        
+        assert page.page_number == 1
+        assert page.content == "Test content"
+        assert isinstance(page.page_number, int)
+        assert isinstance(page.content, str)
+    
+    def test_document_converter_result_with_pages(self):
+        """Test DocumentConverterResult with pages parameter."""
+        pages = [
+            PageInfo(page_number=1, content="Page 1 content"),
+            PageInfo(page_number=2, content="Page 2 content")
+        ]
+        
+        result = DocumentConverterResult(
+            markdown="Combined content",
+            title="Test Document",
+            pages=pages
+        )
+        
+        assert result.markdown == "Combined content"
+        assert result.title == "Test Document"
+        assert len(result.pages) == 2
+        assert result.pages[0].page_number == 1
+        assert result.pages[1].page_number == 2
+    
+    def test_backward_compatibility(self):
+        """Test that all existing functionality remains intact."""
+        if not os.path.exists(self.test_pdf_path):
+            pytest.skip("Test PDF file not found")
+        
+        # Test different ways of calling convert
+        result1 = self.markitdown.convert(self.test_pdf_path)
+        result2 = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
+        
+        # Results should be equivalent
+        assert result1.markdown == result2.markdown
+        assert result1.title == result2.title
+        assert result1.pages == result2.pages
+        
+        # Both should work with string conversion
+        assert str(result1) == str(result2)
+        
+        # Both should work with text_content property
+        assert result1.text_content == result2.text_content
+    
+    def test_non_pdf_file_with_extract_pages(self):
+        """Test that extract_pages parameter doesn't affect non-PDF files."""
+        # Create a temporary markdown file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write("# Test\n\nThis is a test.")
+            temp_path = f.name
+        
+        try:
+            result1 = self.markitdown.convert(temp_path)
+            result2 = self.markitdown.convert(temp_path, extract_pages=True)
+            
+            # Both should behave the same for non-PDF files
+            assert result1.markdown == result2.markdown
+            assert result1.pages is None
+            assert result2.pages is None
+        
+        finally:
+            os.unlink(temp_path)
+    
+    def test_extract_pages_parameter_types(self):
+        """Test different types for extract_pages parameter."""
+        if not os.path.exists(self.test_pdf_path):
+            pytest.skip("Test PDF file not found")
+        
+        # Test with different truthy/falsy values
+        result_false = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
+        result_true = self.markitdown.convert(self.test_pdf_path, extract_pages=True)
+        result_none = self.markitdown.convert(self.test_pdf_path, extract_pages=None)
+        result_zero = self.markitdown.convert(self.test_pdf_path, extract_pages=0)
+        result_one = self.markitdown.convert(self.test_pdf_path, extract_pages=1)
+        
+        # False, None, 0 should not extract pages
+        assert result_false.pages is None
+        assert result_none.pages is None
+        assert result_zero.pages is None
+        
+        # True, 1 should extract pages
+        assert result_true.pages is not None
+        assert result_one.pages is not None

--- a/packages/markitdown/tests/test_pdf_page_extraction.py
+++ b/packages/markitdown/tests/test_pdf_page_extraction.py
@@ -13,42 +13,40 @@ from markitdown import MarkItDown, PageInfo, DocumentConverterResult
 
 class TestPdfPageExtraction:
     """Test cases for PDF page extraction functionality."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.markitdown = MarkItDown()
         self.test_pdf_path = os.path.join(
-            os.path.dirname(__file__), 
-            'test_files', 
-            'test.pdf'
+            os.path.dirname(__file__), "test_files", "test.pdf"
         )
-    
+
     def test_traditional_pdf_conversion(self):
         """Test that traditional PDF conversion works unchanged."""
         if not os.path.exists(self.test_pdf_path):
             pytest.skip("Test PDF file not found")
-        
+
         result = self.markitdown.convert(self.test_pdf_path)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None  # Should be None by default
-        
+
         # Verify backward compatibility
-        assert hasattr(result, 'text_content')
+        assert hasattr(result, "text_content")
         assert result.text_content == result.markdown
         assert str(result) == result.markdown
-    
+
     def test_pdf_page_extraction_enabled(self):
         """Test PDF conversion with page extraction enabled."""
         if not os.path.exists(self.test_pdf_path):
             pytest.skip("Test PDF file not found")
-        
+
         result = self.markitdown.convert(self.test_pdf_path, extract_pages=True)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
@@ -56,7 +54,7 @@ class TestPdfPageExtraction:
         assert result.pages is not None
         assert isinstance(result.pages, list)
         assert len(result.pages) > 0
-        
+
         # Verify page structure
         for page in result.pages:
             assert isinstance(page, PageInfo)
@@ -64,108 +62,106 @@ class TestPdfPageExtraction:
             assert page.page_number > 0
             assert isinstance(page.content, str)
             assert len(page.content) > 0
-        
+
         # Verify page numbers are sequential
         page_numbers = [page.page_number for page in result.pages]
         assert page_numbers == list(range(1, len(result.pages) + 1))
-    
+
     def test_pdf_page_extraction_disabled(self):
         """Test PDF conversion with page extraction explicitly disabled."""
         if not os.path.exists(self.test_pdf_path):
             pytest.skip("Test PDF file not found")
-        
+
         result = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
-        
+
         # Should behave the same as default
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None
-    
+
     def test_page_info_class(self):
         """Test PageInfo class functionality."""
         page = PageInfo(page_number=1, content="Test content")
-        
+
         assert page.page_number == 1
         assert page.content == "Test content"
         assert isinstance(page.page_number, int)
         assert isinstance(page.content, str)
-    
+
     def test_document_converter_result_with_pages(self):
         """Test DocumentConverterResult with pages parameter."""
         pages = [
             PageInfo(page_number=1, content="Page 1 content"),
-            PageInfo(page_number=2, content="Page 2 content")
+            PageInfo(page_number=2, content="Page 2 content"),
         ]
-        
+
         result = DocumentConverterResult(
-            markdown="Combined content",
-            title="Test Document",
-            pages=pages
+            markdown="Combined content", title="Test Document", pages=pages
         )
-        
+
         assert result.markdown == "Combined content"
         assert result.title == "Test Document"
         assert len(result.pages) == 2
         assert result.pages[0].page_number == 1
         assert result.pages[1].page_number == 2
-    
+
     def test_backward_compatibility(self):
         """Test that all existing functionality remains intact."""
         if not os.path.exists(self.test_pdf_path):
             pytest.skip("Test PDF file not found")
-        
+
         # Test different ways of calling convert
         result1 = self.markitdown.convert(self.test_pdf_path)
         result2 = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
-        
+
         # Results should be equivalent
         assert result1.markdown == result2.markdown
         assert result1.title == result2.title
         assert result1.pages == result2.pages
-        
+
         # Both should work with string conversion
         assert str(result1) == str(result2)
-        
+
         # Both should work with text_content property
         assert result1.text_content == result2.text_content
-    
+
     def test_non_pdf_file_with_extract_pages(self):
         """Test that extract_pages parameter doesn't affect non-PDF files."""
         # Create a temporary markdown file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
             f.write("# Test\n\nThis is a test.")
             temp_path = f.name
-        
+
         try:
             result1 = self.markitdown.convert(temp_path)
             result2 = self.markitdown.convert(temp_path, extract_pages=True)
-            
+
             # Both should behave the same for non-PDF files
             assert result1.markdown == result2.markdown
             assert result1.pages is None
             assert result2.pages is None
-        
+
         finally:
             os.unlink(temp_path)
-    
+
     def test_extract_pages_parameter_types(self):
         """Test different types for extract_pages parameter."""
         if not os.path.exists(self.test_pdf_path):
             pytest.skip("Test PDF file not found")
-        
+
         # Test with different truthy/falsy values
         result_false = self.markitdown.convert(self.test_pdf_path, extract_pages=False)
         result_true = self.markitdown.convert(self.test_pdf_path, extract_pages=True)
         result_none = self.markitdown.convert(self.test_pdf_path, extract_pages=None)
         result_zero = self.markitdown.convert(self.test_pdf_path, extract_pages=0)
         result_one = self.markitdown.convert(self.test_pdf_path, extract_pages=1)
-        
+
         # False, None, 0 should not extract pages
         assert result_false.pages is None
         assert result_none.pages is None
         assert result_zero.pages is None
-        
+
         # True, 1 should extract pages
         assert result_true.pages is not None
         assert result_one.pages is not None

--- a/packages/markitdown/tests/test_pptx_page_extraction.py
+++ b/packages/markitdown/tests/test_pptx_page_extraction.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3 -m pytest
+"""
+Unit tests for PPTX slide extraction functionality.
+"""
+
+import os
+import tempfile
+import pytest
+from typing import Optional
+
+from markitdown import MarkItDown, PageInfo, DocumentConverterResult
+
+
+class TestPptxPageExtraction:
+    """Test cases for PPTX slide extraction functionality."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.markitdown = MarkItDown()
+        self.test_pptx_path = os.path.join(
+            os.path.dirname(__file__), 
+            'test_files', 
+            'test.pptx'
+        )
+    
+    def test_traditional_pptx_conversion(self):
+        """Test that traditional PPTX conversion works unchanged."""
+        if not os.path.exists(self.test_pptx_path):
+            pytest.skip("Test PPTX file not found")
+        
+        result = self.markitdown.convert(self.test_pptx_path)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None  # Should be None by default
+        
+        # Verify backward compatibility
+        assert hasattr(result, 'text_content')
+        assert result.text_content == result.markdown
+        assert str(result) == result.markdown
+    
+    def test_pptx_page_extraction_enabled(self):
+        """Test PPTX conversion with slide extraction enabled."""
+        if not os.path.exists(self.test_pptx_path):
+            pytest.skip("Test PPTX file not found")
+        
+        result = self.markitdown.convert(self.test_pptx_path, extract_pages=True)
+        
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is not None
+        assert isinstance(result.pages, list)
+        assert len(result.pages) > 0
+        
+        # Verify page structure
+        for page in result.pages:
+            assert isinstance(page, PageInfo)
+            assert isinstance(page.page_number, int)
+            assert page.page_number > 0
+            assert isinstance(page.content, str)
+            # Slides can be empty, so we don't check content length
+        
+        # Verify page numbers are sequential
+        page_numbers = [page.page_number for page in result.pages]
+        assert page_numbers == list(range(1, len(result.pages) + 1))
+        
+        # Verify each slide has slide number comment
+        for page in result.pages:
+            assert f"<!-- Slide number: {page.page_number} -->" in page.content
+    
+    def test_pptx_page_extraction_disabled(self):
+        """Test PPTX conversion with slide extraction explicitly disabled."""
+        if not os.path.exists(self.test_pptx_path):
+            pytest.skip("Test PPTX file not found")
+        
+        result = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
+        
+        # Should behave the same as default
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None
+    
+    def test_backward_compatibility(self):
+        """Test that all existing functionality remains intact."""
+        if not os.path.exists(self.test_pptx_path):
+            pytest.skip("Test PPTX file not found")
+        
+        # Test different ways of calling convert
+        result1 = self.markitdown.convert(self.test_pptx_path)
+        result2 = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
+        
+        # Results should be equivalent
+        assert result1.markdown == result2.markdown
+        assert result1.title == result2.title
+        assert result1.pages == result2.pages
+        
+        # Both should work with string conversion
+        assert str(result1) == str(result2)
+        
+        # Both should work with text_content property
+        assert result1.text_content == result2.text_content
+    
+    def test_extract_pages_parameter_types(self):
+        """Test different types for extract_pages parameter."""
+        if not os.path.exists(self.test_pptx_path):
+            pytest.skip("Test PPTX file not found")
+        
+        # Test with different truthy/falsy values
+        result_false = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
+        result_true = self.markitdown.convert(self.test_pptx_path, extract_pages=True)
+        result_none = self.markitdown.convert(self.test_pptx_path, extract_pages=None)
+        result_zero = self.markitdown.convert(self.test_pptx_path, extract_pages=0)
+        result_one = self.markitdown.convert(self.test_pptx_path, extract_pages=1)
+        
+        # False, None, 0 should not extract pages
+        assert result_false.pages is None
+        assert result_none.pages is None
+        assert result_zero.pages is None
+        
+        # True, 1 should extract pages
+        assert result_true.pages is not None
+        assert result_one.pages is not None

--- a/packages/markitdown/tests/test_pptx_page_extraction.py
+++ b/packages/markitdown/tests/test_pptx_page_extraction.py
@@ -13,42 +13,40 @@ from markitdown import MarkItDown, PageInfo, DocumentConverterResult
 
 class TestPptxPageExtraction:
     """Test cases for PPTX slide extraction functionality."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.markitdown = MarkItDown()
         self.test_pptx_path = os.path.join(
-            os.path.dirname(__file__), 
-            'test_files', 
-            'test.pptx'
+            os.path.dirname(__file__), "test_files", "test.pptx"
         )
-    
+
     def test_traditional_pptx_conversion(self):
         """Test that traditional PPTX conversion works unchanged."""
         if not os.path.exists(self.test_pptx_path):
             pytest.skip("Test PPTX file not found")
-        
+
         result = self.markitdown.convert(self.test_pptx_path)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None  # Should be None by default
-        
+
         # Verify backward compatibility
-        assert hasattr(result, 'text_content')
+        assert hasattr(result, "text_content")
         assert result.text_content == result.markdown
         assert str(result) == result.markdown
-    
+
     def test_pptx_page_extraction_enabled(self):
         """Test PPTX conversion with slide extraction enabled."""
         if not os.path.exists(self.test_pptx_path):
             pytest.skip("Test PPTX file not found")
-        
+
         result = self.markitdown.convert(self.test_pptx_path, extract_pages=True)
-        
+
         # Verify result structure
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
@@ -56,7 +54,7 @@ class TestPptxPageExtraction:
         assert result.pages is not None
         assert isinstance(result.pages, list)
         assert len(result.pages) > 0
-        
+
         # Verify page structure
         for page in result.pages:
             assert isinstance(page, PageInfo)
@@ -64,65 +62,65 @@ class TestPptxPageExtraction:
             assert page.page_number > 0
             assert isinstance(page.content, str)
             # Slides can be empty, so we don't check content length
-        
+
         # Verify page numbers are sequential
         page_numbers = [page.page_number for page in result.pages]
         assert page_numbers == list(range(1, len(result.pages) + 1))
-        
+
         # Verify each slide has slide number comment
         for page in result.pages:
             assert f"<!-- Slide number: {page.page_number} -->" in page.content
-    
+
     def test_pptx_page_extraction_disabled(self):
         """Test PPTX conversion with slide extraction explicitly disabled."""
         if not os.path.exists(self.test_pptx_path):
             pytest.skip("Test PPTX file not found")
-        
+
         result = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
-        
+
         # Should behave the same as default
         assert isinstance(result, DocumentConverterResult)
         assert isinstance(result.markdown, str)
         assert len(result.markdown) > 0
         assert result.pages is None
-    
+
     def test_backward_compatibility(self):
         """Test that all existing functionality remains intact."""
         if not os.path.exists(self.test_pptx_path):
             pytest.skip("Test PPTX file not found")
-        
+
         # Test different ways of calling convert
         result1 = self.markitdown.convert(self.test_pptx_path)
         result2 = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
-        
+
         # Results should be equivalent
         assert result1.markdown == result2.markdown
         assert result1.title == result2.title
         assert result1.pages == result2.pages
-        
+
         # Both should work with string conversion
         assert str(result1) == str(result2)
-        
+
         # Both should work with text_content property
         assert result1.text_content == result2.text_content
-    
+
     def test_extract_pages_parameter_types(self):
         """Test different types for extract_pages parameter."""
         if not os.path.exists(self.test_pptx_path):
             pytest.skip("Test PPTX file not found")
-        
+
         # Test with different truthy/falsy values
         result_false = self.markitdown.convert(self.test_pptx_path, extract_pages=False)
         result_true = self.markitdown.convert(self.test_pptx_path, extract_pages=True)
         result_none = self.markitdown.convert(self.test_pptx_path, extract_pages=None)
         result_zero = self.markitdown.convert(self.test_pptx_path, extract_pages=0)
         result_one = self.markitdown.convert(self.test_pptx_path, extract_pages=1)
-        
+
         # False, None, 0 should not extract pages
         assert result_false.pages is None
         assert result_none.pages is None
         assert result_zero.pages is None
-        
+
         # True, 1 should extract pages
         assert result_true.pages is not None
         assert result_one.pages is not None

--- a/packages/markitdown/tests/test_xlsx_page_extraction.py
+++ b/packages/markitdown/tests/test_xlsx_page_extraction.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3 -m pytest
+"""
+Unit tests for xlsx sheet extraction functionality.
+"""
+
+import os
+import tempfile
+import pytest
+from typing import Optional
+
+from markitdown import MarkItDown, PageInfo, DocumentConverterResult
+
+
+class TestXlsxPageExtraction:
+    """Test cases for XLSX sheet extraction functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.markitdown = MarkItDown()
+        self.test_xlsx_path = os.path.join(
+            os.path.dirname(__file__), "test_files", "test.xlsx"
+        )
+
+    def test_traditional_xlsx_conversion(self):
+        """Test that traditional XLSX conversion works unchanged."""
+        if not os.path.exists(self.test_xlsx_path):
+            pytest.skip("Test xlsx file not found")
+
+        result = self.markitdown.convert(self.test_xlsx_path)
+
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None  # Should be None by default
+
+        # Verify backward compatibility
+        assert hasattr(result, "text_content")
+        assert result.text_content == result.markdown
+        assert str(result) == result.markdown
+
+    def test_xlsx_page_extraction_enabled(self):
+        """Test xlsx conversion with sheet extraction enabled."""
+        if not os.path.exists(self.test_xlsx_path):
+            pytest.skip("Test xlsx file not found")
+
+        result = self.markitdown.convert(self.test_xlsx_path, extract_pages=True)
+
+        # Verify result structure
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is not None
+        assert isinstance(result.pages, list)
+        assert len(result.pages) > 0
+
+        # Verify page structure
+        for page in result.pages:
+            assert isinstance(page, PageInfo)
+            assert isinstance(page.page_number, int)
+            assert page.page_number > 0
+            assert isinstance(page.content, str)
+
+        # Verify page numbers are sequential
+        page_numbers = [page.page_number for page in result.pages]
+        assert page_numbers == list(range(1, len(result.pages) + 1))
+
+        # Verify markdown text is equal to concatenation of pages
+        assert result.markdown == "\n\n".join([elem.content for elem in result.pages])
+
+    def test_xlsx_page_extraction_disabled(self):
+        """Test xlsx conversion with sheet extraction explicitly disabled."""
+        if not os.path.exists(self.test_xlsx_path):
+            pytest.skip("Test xlsx file not found")
+
+        result = self.markitdown.convert(self.test_xlsx_path, extract_pages=False)
+
+        # Should behave the same as default
+        assert isinstance(result, DocumentConverterResult)
+        assert isinstance(result.markdown, str)
+        assert len(result.markdown) > 0
+        assert result.pages is None
+
+    def test_backward_compatibility(self):
+        """Test that all existing functionality remains intact."""
+        if not os.path.exists(self.test_xlsx_path):
+            pytest.skip("Test xlsx file not found")
+
+        # Test different ways of calling convert
+        result1 = self.markitdown.convert(self.test_xlsx_path)
+        result2 = self.markitdown.convert(self.test_xlsx_path, extract_pages=False)
+
+        # Results should be equivalent
+        assert result1.markdown == result2.markdown
+        assert result1.title == result2.title
+        assert result1.pages == result2.pages
+
+        # Both should work with string conversion
+        assert str(result1) == str(result2)
+
+        # Both should work with text_content property
+        assert result1.text_content == result2.text_content
+
+    def test_extract_pages_parameter_types(self):
+        """Test different types for extract_pages parameter."""
+        if not os.path.exists(self.test_xlsx_path):
+            pytest.skip("Test xlsx file not found")
+
+        # Test with different truthy/falsy values
+        result_false = self.markitdown.convert(self.test_xlsx_path, extract_pages=False)
+        result_true = self.markitdown.convert(self.test_xlsx_path, extract_pages=True)
+        result_none = self.markitdown.convert(self.test_xlsx_path, extract_pages=None)
+        result_zero = self.markitdown.convert(self.test_xlsx_path, extract_pages=0)
+        result_one = self.markitdown.convert(self.test_xlsx_path, extract_pages=1)
+
+        # False, None, 0 should not extract pages
+        assert result_false.pages is None
+        assert result_none.pages is None
+        assert result_zero.pages is None
+
+        # True, 1 should extract pages
+        assert result_true.pages is not None
+        assert result_one.pages is not None


### PR DESCRIPTION
Add docx pagination for soft breaks, add pagination for xlsx where pages=sheets and refactor pdf pagination to use high level page extraction. Docx pagination is not perfect but it works well for some documents, better than nothing I say.

@jeonsworld This is something that is needed for our project and I thought they could be good additions. However feel free to ignore them if not needed or not good enough and do let me know if I should change something. Thank you.
